### PR TITLE
Create Docker Compose demo for GUIs on macOS hosts

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -13,3 +13,24 @@ services:
 
     volumes: # Mount the working directory into the container
       - .:/docker/
+
+  # Container demonstrating a Docker GUI for a macOS host machine
+  #
+  # To run the container with GUI support:
+  #   1. Open XQuartz using the command:    open -a XQuartz
+  #   2. Within XQuartz > Preferences... > Security, check the boxes:
+  #     "Authenticate connections" and "Allow connections from network clients"
+  #   3. Restart (close then re-open) XQuartz if settings were changed
+  #   4. Provide xhost access to Docker by running from Terminal:   xhost +localhost
+  #   5. Launch the container using the command:    docker compose up gui-mac-host
+  #
+  # You should see a pair of eyes, gaze following the mouse, in a windowed GUI
+  gui-mac-host:
+    extends:
+      file: ./compose/core-compose.yaml
+      service: base-gui-mac-host
+
+    build: # Command:     docker compose --progress plain build gui-mac-host
+      context: ./dockerfiles/
+      dockerfile: gui-test.Dockerfile
+      target: gui-test

--- a/compose/core-compose.yaml
+++ b/compose/core-compose.yaml
@@ -24,6 +24,13 @@ services:
     volumes:
       - /tmp/.X11-unix:/tmp/.X11-unix # Mount the X11 Unix socket to support GUIs
 
+  base-gui-mac-host: # Base service supporting in-container GUIs on macOS hosts
+    extends:
+      service: base-cli # Extend a service configuring the container's CLI
+
+    environment: # Set the DISPLAY environment variable for use with XQuartz
+      - DISPLAY=docker.for.mac.host.internal:0
+
   base-nvidia-ubuntu: # Service using NVIDIA GPU(s) for in-Docker GUIs on Ubuntu hosts
     extends:
       service: base-gui-ubuntu # Extend a service configuring support for GUIs

--- a/dockerfiles/gui-test.Dockerfile
+++ b/dockerfiles/gui-test.Dockerfile
@@ -1,0 +1,8 @@
+# Minimal Ubuntu image to test GUI support on various host machines
+FROM ubuntu:24.04 AS gui-test
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends x11-apps && \
+    rm -rf /var/lib/apt/lists/* && apt-get clean
+
+ENTRYPOINT ["xeyes"]


### PR DESCRIPTION
This branch introduces a base Docker Compose configuration to support in-container GUIs on macOS host machines.

**Done When**: Demo works as expected when copy-pasted from its instructions.